### PR TITLE
Fix: Update search results after database update

### DIFF
--- a/search.py
+++ b/search.py
@@ -3,13 +3,21 @@ import numpy as np
 import pandas as pd
 import os
 import time
-from update import database_location
 
 
-# Import Database
-fields = ['name','path'] # The fields we want from the datafile
-data = pd.read_csv(database_location, usecols = fields, low_memory = False) # Read the data into a pandas dataframe
+COLUMNS = ['name','path'] # The fields we want from the datafile
 
+database_location = ""
+data = pd.DataFrame(columns = COLUMNS) #initialise an empty dataframe
+
+def update_data():
+    # Import Database
+    global data
+    try:
+        data = pd.read_csv(database_location, usecols = COLUMNS, low_memory = False) # Read the data into a pandas dataframe
+    except:
+        pass # fail silently
+    
 # Search function
 def searchcsv(SearchString):
     '''

--- a/update.py
+++ b/update.py
@@ -2,24 +2,22 @@ import numpy as np
 import pandas as pd
 from src.folderstats import folderstats
 
-database_location = "..\\Eva - Dependencies\\database.csv"
-folders_location = "..\\Eva - Dependencies\\folders.txt"
 
-def read_folders():
+def read_folders(folders_location):
     with open(folders_location, 'r') as f:
         text = f.read()
     folders = text.split('\n')
     return folders
 
-def write_folders(folders):
+def write_folders(folders, folders_location):
     text = '\n'.join(folders)
     with open(folders_location, 'w') as f:
         f.write(text)
 
-def update():
+def update(database_location, folders_location):
      # These are the folders we crawl through to collect information
-    source_folders = read_folders()
-    all_files_to_csv(source_folders, database_location)
+    source_folders = read_folders(folders_location)
+    return all_files_to_csv(source_folders, database_location)
 
 # Update function
 def all_files_to_csv(source_folders, csv_file):


### PR DESCRIPTION
This addresses the bug where an update saves the new file list to a csv file, but does not update the in-memory dataframe that is used for displaying search results