### PR TITLE
Add ability to limit number of results displayed

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,8 @@ DEP_FOLDER = "..\\Eva - Dependencies\\"
 DATABASE_LOCATION = DEP_FOLDER + "database.csv"
 FOLDERS_LOCATION = DEP_FOLDER + "folders.txt"
 
+DEFAULT_SEARCH_RESULT_LIMIT = 100
+
 app = Flask(__name__)
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 
@@ -31,15 +33,20 @@ def home():
 def search():
     query = request.args.get('q') or ""
     raw = (request.args.get('raw') or "") != ""
+    limit = int(request.args.get('limit') or DEFAULT_SEARCH_RESULT_LIMIT)
+    print({'limit':limit})
     if query:
         results = Search.searchcsv(query)
         hits = len(results)
         if hits == 0:
             results_dict = [{'name':'No files were found!', 'path':'Please adjust your search criteria and try again.'}]
-        else:   
+        else:
+            if limit > 0 and hits > limit:
+                results = results.head(limit)
+            returned_hits = len(results)
             results_dict = results.to_dict('records')
         template = 'results.html' if not raw else 'results_raw.html'
-        return render_template(template, results=results_dict, searchcriteria=query, hits=hits)
+        return render_template(template, results=results_dict, searchcriteria=query, hits=hits, returned_hits=returned_hits)
     else:
         return render_template('search.html')
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -302,6 +302,10 @@ h2,h3,h4{
     color: #333;
 }
 
+.showall-link {
+    color: #ed0080;
+}
+
 
 #pwd{
     border-radius: 2px;

--- a/templates/macros/results_list.html
+++ b/templates/macros/results_list.html
@@ -1,5 +1,12 @@
-{% macro results_list(results, searchcriteria, hits) -%}
-<div style="margin-bottom: 20px;" class="search-results-count">Showing results for {{searchcriteria}} ({{hits}} hits)</div>
+{% macro results_list(results, searchcriteria, hits, returned_hits) -%}
+<div style="margin-bottom: 20px;" class="search-results-count">
+  {% if returned_hits != hits %}
+    Showing {{returned_hits}} of {{hits}} hits for '{{searchcriteria}}'.
+    <a class="showall-link" href="{{ url_for('search') }}?limit=0&q={{searchcriteria}}">Show all</a>
+  {% else %}
+    {{hits}} hits for '{{searchcriteria}}'.
+  {% endif %} 
+</div>
 {% for result in results %}
     {{results_item(result)}}
 {% endfor%}

--- a/templates/results.html
+++ b/templates/results.html
@@ -21,7 +21,7 @@
 
     {% block content %}
     <div id="search-results">
-      {{ results_list(results, searchcriteria, hits) }}
+      {{ results_list(results, searchcriteria, hits, returned_hits) }}
     </div>
     
     


### PR DESCRIPTION
This PR implements the following changes to **search**:

* Add a "limit" query parameter to limit the number of displayed results
* the parameter defaults to 100
* if the parameter is set to '0', all results are displayed
* If the limit bites, the results count message states "showing x of y results" and includes a show all link
* If the limit does not bite, the results count message remains the same as before

This paves the way for potentially making search result cards more complex in future without grinding the browser to a halt because of having to render too many components.

## Some examples:

#### many results, with no query param shows 100 results and a link to show all results
![image](https://user-images.githubusercontent.com/13088589/78450609-1fd27880-7680-11ea-9943-e5690cb2beb6.png)

#### many results with `limit=0` query param shows all results as before
![image](https://user-images.githubusercontent.com/13088589/78450631-485a7280-7680-11ea-99ff-cb894ecdbe1c.png)

#### custom value for `limit` query param

![image](https://user-images.githubusercontent.com/13088589/78450804-7ab89f80-7681-11ea-8af3-897604fc89d2.png)
 

#### when results are below limit, results count message is similar to before
![image](https://user-images.githubusercontent.com/13088589/78450832-ba7f8700-7681-11ea-8eaa-88b26bca278e.png)




